### PR TITLE
6 - Add health check

### DIFF
--- a/lib/spaced_rep_web/endpoint.ex
+++ b/lib/spaced_rep_web/endpoint.ex
@@ -1,5 +1,8 @@
 defmodule SpacedRepWeb.Endpoint do
+  alias SpacedRepWeb.HealthCheck
   use Phoenix.Endpoint, otp_app: :spaced_rep
+
+  plug HealthCheck
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.

--- a/lib/spaced_rep_web/health_check.ex
+++ b/lib/spaced_rep_web/health_check.ex
@@ -1,0 +1,14 @@
+ # Reference: https://blog.jola.dev/health-checks-for-plug-and-phoenix
+defmodule SpacedRepWeb.HealthCheck do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: "/health"} = conn, _opts) do
+    conn
+    |> send_resp(200, "healthy")
+    |> halt()
+  end
+
+  def call(conn, _opts), do: conn
+end


### PR DESCRIPTION
Added a plug that checks if request is a health check, i.e. is for /health. Returns a 200 in yes and passes the through if not.

A health check is needed to allow any monitoring tool to detect if app is healthy. Note the need to add a health check only arose when a load balancer was needed to route incoming traffic to distributed app.

The implemented solution was copied from https://blog.jola.dev/health-checks-for-plug-and-phoenix