### PR TITLE
34 create decks import endpoint

### DIFF
--- a/lib/spaced_rep/decks/deck.ex
+++ b/lib/spaced_rep/decks/deck.ex
@@ -15,12 +15,12 @@ defmodule SpacedRep.Decks.Deck do
     timestamps()
   end
 
-  @doc false
   def changeset(deck, user_id, attrs) do
     deck
     |> change(%{user_id: user_id})
     |> cast(attrs, [:description, :name, :user_id])
     |> validate_required([:name])
+    |> unique_constraint(:name)
     |> cast_assoc(:cards)
   end
 

--- a/lib/spaced_rep_web/plugs/upload_verification_plug.ex
+++ b/lib/spaced_rep_web/plugs/upload_verification_plug.ex
@@ -1,13 +1,18 @@
 defmodule SpacedRepWeb.UploadVerificationPlug do
   import Plug.Conn
-
   def init(opts), do: opts
 
-  def call(%Plug.Conn{request_path: "/decks/upload", params: params} = conn, _opts) do
-    upload = params["filename"]
+  '''
+  Expects the contents of a JSON file in plain text. Unfortunately, a way to
+  a proper file from the upstream service, i.e. user management was not found.
 
-    with {:ok, raw_content} = File.read(upload.path),
-         {:ok, decoded_content} = Jason.decode(raw_content) do
+  NOTE: Once a proper API Gateway is found, the upstream service will be retired
+  '''
+
+  def call(%Plug.Conn{request_path: "/decks/upload", params: params} = conn, _opts) do
+    data = params["data"]
+
+    with {:ok, decoded_content} = Jason.decode(data) do
       case validate_content(decoded_content) do
         {:ok, valid_content} -> assign(conn, :data, valid_content)
         {:error, _} -> send_resp(conn, 422, "Attempted to upload invalid data") |> halt()


### PR DESCRIPTION
Update upload endpoint so that it accepts the content of an uploaded file in a form instead of a file itself. This change was necessary, because sending a file from the upstream service, i.e. user management service, seemed to be more work than necessary.

Closes #34 