### PR TITLE
42 Return full data in deck response

### DIFF
--- a/lib/spaced_rep/decks.ex
+++ b/lib/spaced_rep/decks.ex
@@ -18,27 +18,12 @@ defmodule SpacedRep.Decks do
       iex> list_decks()
       [%Deck{}, ...]
 
-  """
-  def list_decks do
-    Repo.all(Deck)
-  end
-
-  @doc """
-  Gets all decks including cards.
-
-  Return `nil` if no decks.
-
-  ## Examples
-
-      iex> list_full_decks()
-      [%Deck{}]
-
-      iex> list_full_decks(456)
+      iex> list_decks()
       nil
 
   """
-  def list_full_decks do
-    Repo.all(Deck) |> Repo.preload(cards: [:answers])
+  def list_decks do
+    Deck |> Repo.all() |> Repo.preload(cards: [:answers])
   end
 
   @doc """

--- a/lib/spaced_rep_web/controllers/deck_json.ex
+++ b/lib/spaced_rep_web/controllers/deck_json.ex
@@ -12,18 +12,10 @@ defmodule SpacedRepWeb.DeckJSON do
   Renders a single deck.
   """
   def show(%{deck: deck}) do
-    full_data(deck)
+    data(deck)
   end
 
   defp data(%Deck{} = deck) do
-    %{
-      id: deck.id,
-      description: deck.description,
-      name: deck.name
-    }
-  end
-
-  defp full_data(%Deck{} = deck) do
     %{
       id: deck.id,
       description: deck.description,


### PR DESCRIPTION
This MR has changes such that all the data is returned in get decks response. This will increase the payload of the response but, but eventually it will be paginated so there is little risk of a payload so large that it slows the response time.

Closes #42 