### PR TITLE
49 restrict access by user id and deleted status

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -6,10 +6,10 @@ import Config
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 config :spaced_rep, SpacedRep.Repo,
-  username: System.get_env("POSTGRES_USERNAME", "postgres"),
-  password: System.get_env("POSTGRES_PASSWORD", "postgres"),
-  hostname: System.get_env("POSTGRES_HOSTNAME", "localhost"),
-  database: System.get_env("POSTGRES_DB", "spaced_rep_test"),
+  username: System.get_env("DB_USERNAME", "postgres"),
+  password: System.get_env("DB_PASSWORD", "postgres"),
+  hostname: System.get_env("DB_HOSTNAME", "localhost"),
+  database: System.get_env("DB_NAME", "spaced_rep_test"),
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 10
 

--- a/lib/spaced_rep/answers.ex
+++ b/lib/spaced_rep/answers.ex
@@ -37,7 +37,9 @@ defmodule SpacedRep.Answers do
 
   """
   def get_answer(%{"id" => id, "user_id" => user_id}) do
-    query = from a in Answer, where: a.id == ^id and a.user_id == ^user_id
+    query =
+      from a in Answer, where: a.id == ^id and a.user_id == ^user_id and is_nil(a.deleted_at)
+
     Repo.one(query)
   end
 

--- a/lib/spaced_rep/answers.ex
+++ b/lib/spaced_rep/answers.ex
@@ -13,12 +13,12 @@ defmodule SpacedRep.Answers do
 
   ## Examples
 
-      iex> list_answers()
+      iex> list_answers(%{"id" => 123, "user_id" => 456})
       [%Answer{}, ...]
 
   """
-  def list_answers(card_id) do
-    query = from a in Answer, where: a.card_id == ^card_id
+  def list_answers(%{"user_id" => user_id, "card_id" => card_id}) do
+    query = from a in Answer, where: a.user_id == ^user_id and a.card_id == ^card_id
     Repo.all(query)
   end
 
@@ -29,29 +29,32 @@ defmodule SpacedRep.Answers do
 
   ## Examples
 
-      iex> get_answer!(123)
+      iex> get_answer(%{"id" => 123, "user_id" => 456})
       %Answer{}
 
-      iex> get_answer!(456)
-      ** (Ecto.NoResultsError)
+      iex> get_answer(%{"id" => 123, "user_id" => 789})
+      nil
 
   """
-  def get_answer!(id), do: Repo.get!(Answer, id)
+  def get_answer(%{"id" => id, "user_id" => user_id}) do
+    query = from a in Answer, where: a.id == ^id and a.user_id == ^user_id
+    Repo.one(query)
+  end
 
   @doc """
   Creates a answer.
 
   ## Examples
 
-      iex> create_answer(%{field: value})
+      iex> create_answer(%{"id" => 123, "user_id" => 456}, %{content: "How are you?"})
       {:ok, %Answer{}}
 
-      iex> create_answer(%{field: bad_value})
+      iex> create_answer(%{"id" => 123, "user_id" => 456}, %{content: nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_answer(attrs \\ %{}) do
-    %Answer{}
+  def create_answer(%{"user_id" => user_id, "card_id" => card_id}, attrs \\ %{}) do
+    %Answer{user_id: user_id, card_id: card_id}
     |> Answer.changeset(attrs)
     |> Repo.insert()
   end
@@ -61,15 +64,15 @@ defmodule SpacedRep.Answers do
 
   ## Examples
 
-      iex> update_answer(answer, %{field: new_value})
+      iex> update_answer(%{"id" => 123, "user_id" => 456}, %{content: "How is it going?"})
       {:ok, %Answer{}}
 
-      iex> update_answer(answer, %{field: bad_value})
+      iex> update_answer(%{"id" => 123, "user_id" => 456}, %{content: nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_answer(%Answer{} = answer, attrs) do
-    answer
+  def update_answer(%{"id" => id, "user_id" => user_id}, attrs \\ %{}) do
+    %Answer{id: id, user_id: user_id}
     |> Answer.changeset(attrs)
     |> Repo.update()
   end
@@ -79,27 +82,14 @@ defmodule SpacedRep.Answers do
 
   ## Examples
 
-      iex> delete_answer(answer)
+      iex> delete_answer(%{"id" => 123, "user_id" => 456})
       {:ok, %Answer{}}
 
-      iex> delete_answer(answer)
+      iex> delete_answer(delete_answer(%{"id" => 123, "user_id" => 789}))
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_answer(%Answer{} = answer) do
-    Repo.delete(answer)
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking answer changes.
-
-  ## Examples
-
-      iex> change_answer(answer)
-      %Ecto.Changeset{data: %Answer{}}
-
-  """
-  def change_answer(%Answer{} = answer, attrs \\ %{}) do
-    Answer.changeset(answer, attrs)
+  def delete_answer(%{"id" => id, "user_id" => user_id}) do
+    update_answer(%{"id" => id, "user_id" => user_id}, %{"deleted_at" => DateTime.utc_now()})
   end
 end

--- a/lib/spaced_rep/answers/answer.ex
+++ b/lib/spaced_rep/answers/answer.ex
@@ -10,6 +10,8 @@ defmodule SpacedRep.Answers.Answer do
   @timestamps_opts [type: :utc_datetime]
   schema "answers" do
     field :content, :string
+    field :user_id, :binary_id
+    field :deleted_at, :utc_datetime
     belongs_to :card, SpacedRep.Cards.Card
 
     timestamps()

--- a/lib/spaced_rep/answers/answer.ex
+++ b/lib/spaced_rep/answers/answer.ex
@@ -17,7 +17,16 @@ defmodule SpacedRep.Answers.Answer do
     timestamps()
   end
 
-  @doc false
+  @doc """
+  Delete answer changeset
+  """
+  def changeset(answer, %{"deleted_at" => _deleted_at} = attrs) do
+    answer |> cast(attrs, [:deleted_at])
+  end
+
+  @doc """
+  Update answer changeset
+  """
   def changeset(answer, attrs) do
     answer
     |> cast(attrs, [:content])

--- a/lib/spaced_rep/cards.ex
+++ b/lib/spaced_rep/cards.ex
@@ -17,8 +17,11 @@ defmodule SpacedRep.Cards do
       [%Card{}, ...]
 
   """
-  def list_cards(deck_id) do
-    query = from(c in Card, where: c.deck_id == ^deck_id)
+  def list_cards(%{"user_id" => user_id, "deck_id" => deck_id}) do
+    query =
+      from c in Card,
+        where: c.deck_id == ^deck_id and c.user_id == ^user_id and is_nil(c.deleted_at)
+
     Repo.all(query) |> Repo.preload(:answers)
   end
 
@@ -29,17 +32,16 @@ defmodule SpacedRep.Cards do
 
   ## Examples
 
-      iex> get_card!(123)
+      iex> get_card({"id" => 123, "user_id": 456})
       %Card{}
 
-      iex> get_card(456)
+      iex> get_card({"id" => 123, "user_id": 678})
       ** nil
 
   """
-  def get_card(id) do
-    query = from c in Card, where: is_nil(c.deleted_at) and c.id == ^id
-
-    Repo.one(query) |> Repo.preload(:answers)
+  def get_card(%{"id" => id, "user_id" => user_id}) do
+    query = from c in Card, where: c.id == ^id and c.user_id == ^user_id
+    query |> Repo.one() |> Repo.preload(:answers)
   end
 
   @doc """
@@ -47,20 +49,71 @@ defmodule SpacedRep.Cards do
 
   ## Examples
 
-      iex> create_card(%{field: value})
+      iex> create_card(%{"user_id" => 123, "deck_id" => 456}, %{"question"=> "How are you?"})
       {:ok, %Card{}}
 
-      iex> create_card(%{field: bad_value})
+      iex> create_card(%{"user_id" => 123, "deck_id" => 456}, %{"question"=> nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_card(deck_id, attrs \\ %{}) do
-    %Card{}
-    |> Card.changeset(deck_id, attrs)
+  def create_card(%{"user_id" => user_id, "deck_id" => deck_id}, attrs) do
+    %Card{user_id: user_id, deck_id: deck_id}
+    |> Card.changeset(attrs)
     |> Repo.insert()
   end
 
-  defp get_updated_card(card, %{"quality" => quality} = attrs) do
+  # def update_card(%{"id" => id, "user_id" => user_id}, %{"quality" => quality} = attrs)
+  #     when is_nil(quality)
+  #     # TODO Do DB query for card here, then compare quality
+  #     when quality !== card.quality do
+  #   card = get_card(%{"id" => id, "user_id" => user_id})
+
+  #   updated_attrs = get_updated_card(card, attrs)
+
+  #   card
+  #   |> Card.changeset(updated_attrs)
+  #   |> Repo.update()
+  # end
+
+  @doc """
+  Updates a card.
+
+  ## Examples
+
+      iex> update_card(%{"id" => 123, "user_id" => 456}, %{"question" => "Comment ça va?"})
+      {:ok, %Card{}}
+
+      iex> update_card(%{"id" => 123, "user_id" => 456}, %{"question" => nil})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_card(%{"id" => id, "user_id" => user_id}, attrs) do
+    card = get_card(%{"id" => id, "user_id" => user_id})
+    updated_attrs = get_updated_attrs(card, attrs)
+
+    card
+    |> Card.changeset(updated_attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a card.
+
+  ## Examples
+
+      iex> delete_card(%{"id" => 123, "user_id" => 456})
+      {:ok, %Card{}}
+
+      iex> delete_card(%{"id" => 123, "user_id" => 789})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_card(%{"id" => id, "user_id" => user_id}) do
+    update_card(%{"id" => id, "user_id" => user_id}, %{"deleted_at" => DateTime.utc_now()})
+  end
+
+  defp get_updated_attrs(%Card{} = card, %{"quality" => quality} = attrs)
+       when is_number(quality) and card.quality !== quality do
     dq = 5 - quality
     updated_easiness = max(1.3, card.easiness + (0.1 - dq * (0.08 + dq * 0.02)))
     updated_easiness = Float.round(updated_easiness, 1)
@@ -93,62 +146,7 @@ defmodule SpacedRep.Cards do
     )
   end
 
-  def update_card(%Card{} = card, %{"quality" => quality} = attrs)
-      when quality !== card.quality do
-    updated_attrs = get_updated_card(card, attrs)
-
-    card
-    |> Card.changeset(updated_attrs)
-    |> Repo.update()
-  end
-
-  @doc """
-  Updates a card.
-
-  ## Examples
-
-      iex> update_card(card, %{field: new_value})
-      {:ok, %Card{}}
-
-      iex> update_card(card, %{field: bad_value})
-      {:error, %Ecto.Changeset{}}
-
-  """
-
-  def update_card(%Card{} = card, attrs) do
-    card
-    |> Card.changeset(attrs)
-    |> Repo.update()
-  end
-
-  @doc """
-  Deletes a card.
-
-  ## Examples
-
-      iex> delete_card(card)
-      {:ok, %Card{}}
-
-      iex> delete_card(card)
-      {:error, %Ecto.Changeset{}}
-
-  """
-  def delete_card(id) do
-    %Card{id: id}
-    |> change_card(%{deleted_at: DateTime.utc_now()})
-    |> Repo.update()
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking card changes.
-
-  ## Examples
-
-      iex> change_card(card)
-      %Ecto.Changeset{data: %Card{}}
-
-  """
-  def change_card(%Card{} = card, attrs \\ %{}) do
-    Card.changeset(card, attrs)
+  defp get_updated_attrs(%Card{}, attrs) do
+    attrs
   end
 end

--- a/lib/spaced_rep/cards.ex
+++ b/lib/spaced_rep/cards.ex
@@ -40,7 +40,7 @@ defmodule SpacedRep.Cards do
 
   """
   def get_card(%{"id" => id, "user_id" => user_id}) do
-    query = from c in Card, where: c.id == ^id and c.user_id == ^user_id
+    query = from c in Card, where: c.id == ^id and c.user_id == ^user_id and is_nil(c.deleted_at)
     query |> Repo.one() |> Repo.preload(:answers)
   end
 
@@ -61,19 +61,6 @@ defmodule SpacedRep.Cards do
     |> Card.changeset(attrs)
     |> Repo.insert()
   end
-
-  # def update_card(%{"id" => id, "user_id" => user_id}, %{"quality" => quality} = attrs)
-  #     when is_nil(quality)
-  #     # TODO Do DB query for card here, then compare quality
-  #     when quality !== card.quality do
-  #   card = get_card(%{"id" => id, "user_id" => user_id})
-
-  #   updated_attrs = get_updated_card(card, attrs)
-
-  #   card
-  #   |> Card.changeset(updated_attrs)
-  #   |> Repo.update()
-  # end
 
   @doc """
   Updates a card.

--- a/lib/spaced_rep/cards/card.ex
+++ b/lib/spaced_rep/cards/card.ex
@@ -14,6 +14,7 @@ defmodule SpacedRep.Cards.Card do
     field(:easiness, :float, default: 2.5)
     field(:repetitions, :integer, default: 0)
     field(:question, :string)
+    field(:user_id, :binary_id)
 
     field(:next_practice_date, :utc_datetime)
     field :deleted_at, :utc_datetime
@@ -34,7 +35,8 @@ defmodule SpacedRep.Cards.Card do
       :interval,
       :question,
       :repetitions,
-      :next_practice_date
+      :next_practice_date,
+      :user_id
     ])
     |> validate_required([:interval, :question])
     |> validate_number(:easiness, greater_than_or_equal_to: 1.3)
@@ -43,14 +45,18 @@ defmodule SpacedRep.Cards.Card do
     |> cast_assoc(:answers)
   end
 
-  def changeset(card, %{deleted_at: _deleted_at} = attrs) do
+  @doc """
+  Delete card changeset
+  """
+  def changeset(card, %{"deleted_at" => _deleted_at} = attrs) do
     card
-    |> change(attrs)
     |> cast(attrs, [:deleted_at])
   end
 
-  @doc false
-  def changeset(card, attrs) do
+  @doc """
+  Update card changeset
+  """
+  def changeset(card, %{"user_id" => _user_id, "deck_id" => _deck_id} = attrs) do
     card
     |> cast(attrs, [
       :quality,
@@ -58,7 +64,31 @@ defmodule SpacedRep.Cards.Card do
       :interval,
       :question,
       :repetitions,
-      :next_practice_date
+      :next_practice_date,
+      :user_id,
+      :deck_id
+    ])
+    |> validate_required([:interval, :question, :deck_id, :user_id])
+    |> validate_number(:easiness, greater_than_or_equal_to: 1.3)
+    |> validate_number(:quality, greater_than: 0, less_than_or_equal_to: 5)
+    |> unique_constraint(:question)
+    |> cast_assoc(:answers)
+  end
+
+  @doc """
+  Create card changeset
+  """
+  def changeset(card, attrs) do
+    card
+    |> cast(attrs, [
+      :deck_id,
+      :quality,
+      :easiness,
+      :interval,
+      :question,
+      :repetitions,
+      :next_practice_date,
+      :user_id
     ])
     |> validate_required([:interval, :question])
     |> validate_number(:easiness, greater_than_or_equal_to: 1.3)

--- a/lib/spaced_rep/cards/card.ex
+++ b/lib/spaced_rep/cards/card.ex
@@ -2,6 +2,9 @@ defmodule SpacedRep.Cards.Card do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias SpacedRep.Answers.Answer
+  alias SpacedRep.Decks.Deck
+
   @derive {Jason.Encoder,
            only: [:id, :question, :answers, :inserted_at, :updated_at, :deleted_at]}
 
@@ -18,10 +21,14 @@ defmodule SpacedRep.Cards.Card do
 
     field(:next_practice_date, :utc_datetime)
     field :deleted_at, :utc_datetime
-    has_many :answers, SpacedRep.Answers.Answer
-    belongs_to :deck, SpacedRep.Decks.Deck
+    has_many :answers, Answer, defaults: :set_user_id
+    belongs_to :deck, Deck
 
     timestamps()
+  end
+
+  def set_user_id(%Answer{} = answer, %__MODUE__{} = card) do
+    %{answer | user_id: card.user_id}
   end
 
   @doc false

--- a/lib/spaced_rep/cards/card.ex
+++ b/lib/spaced_rep/cards/card.ex
@@ -27,7 +27,7 @@ defmodule SpacedRep.Cards.Card do
     timestamps()
   end
 
-  def set_user_id(%Answer{} = answer, %__MODUE__{} = card) do
+  def set_user_id(%Answer{} = answer, %__MODULE__{} = card) do
     %{answer | user_id: card.user_id}
   end
 

--- a/lib/spaced_rep/decks.ex
+++ b/lib/spaced_rep/decks.ex
@@ -22,8 +22,9 @@ defmodule SpacedRep.Decks do
       nil
 
   """
-  def list_decks do
-    Deck |> Repo.all() |> Repo.preload(cards: [:answers])
+  def list_decks(user_id) do
+    query = from d in Deck, where: d.user_id == ^user_id
+    query |> Repo.all() |> Repo.preload(cards: [:answers])
   end
 
   @doc """
@@ -33,17 +34,16 @@ defmodule SpacedRep.Decks do
 
   ## Examples
 
-      iex> get_deck(123)
+      iex> get_deck(%{"id" => 123, "user_id" => 123})
       %Deck{}
 
-      iex> get_deck(456)
+      iex> get_deck(%{"id" => 123, "user_id" => 456})
       nil
 
   """
-  def get_deck(id) do
-    query = from d in Deck, where: is_nil(d.deleted_at) and d.id == ^id
-
-    Repo.one(query) |> Repo.preload(cards: [:answers])
+  def get_deck(%{"id" => id, "user_id" => user_id}) do
+    query = from d in Deck, where: d.id == ^id and d.user_id == ^user_id
+    query |> Repo.one() |> Repo.preload(cards: [:answers])
   end
 
   @doc """
@@ -51,16 +51,16 @@ defmodule SpacedRep.Decks do
 
   ## Examples
 
-      iex> create_deck(%{field: value})
+      iex> create_deck(%{"name"=> "new deck"})
       {:ok, %Deck{}}
 
-      iex> create_deck(%{field: bad_value})
+      iex> create_deck(%{"name" => nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_deck(user_id, attrs \\ %{}) do
+  def create_deck(attrs \\ %{}) do
     %Deck{}
-    |> Deck.changeset(user_id, attrs)
+    |> Deck.changeset(attrs)
     |> Repo.insert()
     |> case do
       {:ok, deck} -> {:ok, Repo.preload(deck, cards: [:answers])}
@@ -73,15 +73,15 @@ defmodule SpacedRep.Decks do
 
   ## Examples
 
-      iex> update_deck(deck, %{field: new_value})
+      iex> update_deck(123, %{"name" => "updated name"})
       {:ok, %Deck{}}
 
-      iex> update_deck(deck, %{field: bad_value})
+      iex> update_deck(456, %{"name" => nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_deck(%Deck{} = deck, attrs) do
-    deck
+  def update_deck(id, %{"user_id" => _user_id} = attrs) do
+    %Deck{id: id}
     |> Deck.changeset(attrs)
     ## TODO Upsert nested cards and answers
     |> Repo.update()
@@ -96,14 +96,14 @@ defmodule SpacedRep.Decks do
 
   ## Examples
 
-      iex> upload_decks(decks, user_id)
-      {:ok, %Deck{}}
+      iex> upload_decks([%{"user_id" => 123, "name" => "new deck"}])
+      {:ok, [%Deck{}]}
 
-      iex> upload_decks(decks, user_id)
+      iex> upload_decks([%{"user_id" => 123, "name" => nil}])
       {:error, %Ecto.Changeset{}}
 
   """
-  def upload_decks(decks, user_id) do
+  def upload_decks(decks) do
     mapped_decks = Enum.map(decks, &map_imported_deck/1)
 
     ops =
@@ -111,7 +111,7 @@ defmodule SpacedRep.Decks do
         Ecto.Multi.insert(
           acc,
           deck.name,
-          Deck.changeset(deck, user_id, %{})
+          Deck.changeset(%Deck{}, deck)
         )
       end)
 
@@ -123,15 +123,15 @@ defmodule SpacedRep.Decks do
 
   ## Examples
 
-      iex> delete_deck(deck)
-      {:ok, %Deck{}}
+      iex> delete_deck(%{"id" => 123, "user_id" => 456})
+      {:ok, %Deck{deleted_at: 01/01/1970}}
 
-      iex> delete_deck(deck)
+      iex> delete_deck(%{"id" => 123, "user_id" => 678})
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_deck(id) do
-    %Deck{id: id}
+  def delete_deck(%{"id" => id, "user_id" => user_id}) do
+    %Deck{id: id, user_id: user_id}
     |> change_deck(%{deleted_at: DateTime.utc_now()})
     |> Repo.update()
   end
@@ -145,14 +145,13 @@ defmodule SpacedRep.Decks do
       %Ecto.Changeset{data: %Deck{}}
 
   """
-  def change_deck(%Deck{} = deck, attrs \\ %{}) do
+  def change_deck(deck, attrs \\ %{}) do
     Deck.changeset(deck, attrs)
   end
 
-  """
+  @doc """
   Maps a list of %ImportedDeck{} to a list of %Deck{}
   """
-
   defp map_imported_deck(%{"name" => name, "cards" => imported_cards}) do
     map_answers = fn answers ->
       Enum.map(answers, fn answer -> %Answer{content: answer} end)

--- a/lib/spaced_rep/decks.ex
+++ b/lib/spaced_rep/decks.ex
@@ -42,7 +42,7 @@ defmodule SpacedRep.Decks do
 
   """
   def get_deck(%{"id" => id, "user_id" => user_id}) do
-    query = from d in Deck, where: d.id == ^id and d.user_id == ^user_id
+    query = from d in Deck, where: d.id == ^id and d.user_id == ^user_id and is_nil(d.deleted_at)
     query |> Repo.one() |> Repo.preload(cards: [:answers])
   end
 

--- a/lib/spaced_rep/decks/deck.ex
+++ b/lib/spaced_rep/decks/deck.ex
@@ -18,12 +18,17 @@ defmodule SpacedRep.Decks.Deck do
     timestamps()
   end
 
-  def changeset(deck, %{deleted_at: _deleted_at} = attrs) do
+  @doc """
+  Delete deck changeset
+  """
+  def changeset(deck, %{"deleted_at" => _deleted_at} = attrs) do
     deck
-    |> change(attrs)
     |> cast(attrs, [:deleted_at])
   end
 
+  @doc """
+  Update deck changeset
+  """
   def changeset(deck, %{id: _id} = attrs) do
     deck
     |> change(attrs)
@@ -31,6 +36,9 @@ defmodule SpacedRep.Decks.Deck do
     |> cast_assoc(:cards)
   end
 
+  @doc """
+  Create deck changeset
+  """
   def changeset(deck, attrs) do
     deck
     |> cast(attrs, [:description, :name, :user_id])

--- a/lib/spaced_rep/decks/deck.ex
+++ b/lib/spaced_rep/decks/deck.ex
@@ -1,6 +1,9 @@
 defmodule SpacedRep.Decks.Deck do
   use Ecto.Schema
   import Ecto.Changeset
+  require Logger
+
+  alias SpacedRep.Cards.Card
 
   @derive {Jason.Encoder,
            only: [:id, :name, :description, :cards, :inserted_at, :updated_at, :deleted_at]}
@@ -13,9 +16,14 @@ defmodule SpacedRep.Decks.Deck do
     field :description, :string
     field :user_id, :binary_id
     field :deleted_at, :utc_datetime
-    has_many :cards, SpacedRep.Cards.Card
+
+    has_many :cards, Card, defaults: :set_user_id
 
     timestamps()
+  end
+
+  def set_user_id(%Card{} = card, %__MODULE__{} = deck) do
+    %{card | user_id: deck.user_id}
   end
 
   @doc """

--- a/lib/spaced_rep/decks/deck.ex
+++ b/lib/spaced_rep/decks/deck.ex
@@ -18,25 +18,24 @@ defmodule SpacedRep.Decks.Deck do
     timestamps()
   end
 
-  def changeset(deck, user_id, attrs) do
-    deck
-    |> change(%{user_id: user_id})
-    |> cast(attrs, [:description, :name, :user_id])
-    |> validate_required([:name])
-    |> unique_constraint(:name)
-    |> cast_assoc(:cards)
-  end
-
   def changeset(deck, %{deleted_at: _deleted_at} = attrs) do
     deck
     |> change(attrs)
     |> cast(attrs, [:deleted_at])
   end
 
+  def changeset(deck, %{id: _id} = attrs) do
+    deck
+    |> change(attrs)
+    |> unique_constraint(:name)
+    |> cast_assoc(:cards)
+  end
+
   def changeset(deck, attrs) do
     deck
-    |> cast(attrs, [:description, :name])
-    |> validate_required([:name])
+    |> cast(attrs, [:description, :name, :user_id])
+    |> validate_required([:name, :user_id])
+    |> unique_constraint(:name)
     |> cast_assoc(:cards)
   end
 end

--- a/lib/spaced_rep_web/controllers/answer_controller.ex
+++ b/lib/spaced_rep_web/controllers/answer_controller.ex
@@ -12,42 +12,46 @@ defmodule SpacedRepWeb.AnswerController do
   end
 
   def index(conn, %{"card_id" => card_id}, _body_params) do
-    answers = Answers.list_answers(card_id)
+    answers = Answers.list_answers(%{"user_id" => conn.assigns.user_id, "card_id" => card_id})
     render(conn, :index, answers: answers)
   end
 
   def create(conn, %{"deck_id" => deck_id, "card_id" => card_id}, answer_params) do
-    with {:ok, %Answer{} = answer} <- Answers.create_answer(answer_params) do
+    with {:ok, %Answer{} = answer} <-
+           Answers.create_answer(
+             %{"user_id" => conn.assigns.user_id, "card_id" => card_id},
+             answer_params
+           ) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", ~p"/decks/#{deck_id}/cards/#{card_id}/answers/#{answer}")
+      |> put_resp_header("location", ~p"/decks/#{deck_id}/cards/#{card_id}/answers/#{answer.id}")
       |> render(:show, answer: answer)
     end
   end
 
   def show(conn, %{"id" => id}, _body_params) do
-    answer = Answers.get_answer!(id)
+    answer = Answers.get_answer(%{"id" => id, "user_id" => conn.assigns.user_id})
     render(conn, :show, answer: answer)
   end
 
   def update(conn, %{"id" => id}, answer_params) do
-    answer = Answers.get_answer!(id)
-
-    with {:ok, %Answer{} = answer} <- Answers.update_answer(answer, answer_params) do
+    with {:ok, %Answer{} = answer} <-
+           Answers.update_answer(%{"id" => id, "user_id" => conn.assigns.user_id}, answer_params) do
       render(conn, :show, answer: answer)
     end
   end
 
   def delete(conn, %{"id" => id}, _) do
-    answer = Answers.get_answer!(id)
-
-    with {:ok, %Answer{}} <- Answers.delete_answer(answer) do
+    with {:ok, %Answer{}} <-
+           Answers.delete_answer(%{"id" => id, "user_id" => conn.assigns.user_id}) do
       send_resp(conn, :no_content, "")
     end
   end
 
   def check(conn, %{"card_id" => card_id}, %{"answer" => answer}) do
-    with answers <- Answers.list_answers(card_id) do
+    with answers <-
+           Answers.list_answers(%{"user_id" => conn.assigns.user_id, "card_id" => card_id}) do
+      # TODO get_closest should be in the answer context
       %{answer: answer, distance: distance} = get_closest(answer, answers)
       render(conn, :show, answer: answer, distance: distance)
     end

--- a/lib/spaced_rep_web/controllers/card_controller.ex
+++ b/lib/spaced_rep_web/controllers/card_controller.ex
@@ -12,34 +12,38 @@ defmodule SpacedRepWeb.CardController do
   end
 
   def index(conn, %{"deck_id" => deck_id}, _) do
-    cards = Cards.list_cards(deck_id)
+    cards = Cards.list_cards(%{"user_id" => conn.assigns.user_id, "deck_id" => deck_id})
     render(conn, :index, cards: cards)
   end
 
   def create(conn, %{"deck_id" => deck_id}, card_params) do
-    with {:ok, %Card{} = card} <- Cards.create_card(deck_id, card_params) do
+    with {:ok, %Card{} = card} <-
+           Cards.create_card(
+             %{"user_id" => conn.assigns.user_id, "deck_id" => deck_id},
+             card_params
+           ) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", ~p"/decks/#{deck_id}/cards/#{card}")
+      |> put_resp_header("location", ~p"/decks/#{deck_id}/cards/#{card.id}")
       |> render(:show, card: card)
     end
   end
 
   def show(conn, %{"id" => id}, _) do
-    with %Card{} = card <- Cards.get_card(id) do
+    with %Card{} = card <- Cards.get_card(%{"id" => id, "user_id" => conn.assigns.user_id}) do
       render(conn, :show, card: card)
     end
   end
 
   def update(conn, %{"id" => id}, card_params) do
-    with %Card{} = card <- Cards.get_card(id),
-         {:ok, %Card{} = updated_card} <- Cards.update_card(card, card_params) do
+    with {:ok, %Card{} = updated_card} <-
+           Cards.update_card(%{"id" => id, "user_id" => conn.assigns.user_id}, card_params) do
       render(conn, :show, card: updated_card)
     end
   end
 
   def delete(conn, %{"id" => id}, _) do
-    with {:ok, %Card{}} <- Cards.delete_card(id) do
+    with {:ok, %Card{}} <- Cards.delete_card(%{"id" => id, "user_id" => conn.assigns.user_id}) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/lib/spaced_rep_web/controllers/deck_controller.ex
+++ b/lib/spaced_rep_web/controllers/deck_controller.ex
@@ -12,13 +12,11 @@ defmodule SpacedRepWeb.DeckController do
   end
 
   def create(conn, deck_params) do
-    deck_params_with_user_id = Map.put_new(deck_params, "user_id", conn.assigns.user_id)
-
     with {:ok, %Deck{} = deck} <-
-           Decks.create_deck(deck_params_with_user_id) do
+           Decks.create_deck(%{"user_id" => conn.assigns.user_id}, deck_params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", ~p"/decks/#{deck}")
+      |> put_resp_header("location", ~p"/decks/#{deck.id}")
       |> render(:show, deck: deck)
     end
   end
@@ -31,7 +29,7 @@ defmodule SpacedRepWeb.DeckController do
 
   def update(conn, %{"id" => id} = deck_params) do
     with {:ok, %Deck{} = deck} <-
-           Decks.update_deck(id, Map.put_new(deck_params, "user_id", conn.assigns.user_id)) do
+           Decks.update_deck(%{"id" => id, "user_id" => conn.assigns.user_id}, deck_params) do
       render(conn, :show, deck: deck)
     end
   end

--- a/lib/spaced_rep_web/controllers/deck_controller.ex
+++ b/lib/spaced_rep_web/controllers/deck_controller.ex
@@ -7,12 +7,15 @@ defmodule SpacedRepWeb.DeckController do
   action_fallback SpacedRepWeb.FallbackController
 
   def index(conn, _params) do
-    decks = Decks.list_decks()
+    decks = Decks.list_decks(conn.assigns.user_id)
     render(conn, :index, decks: decks)
   end
 
   def create(conn, deck_params) do
-    with {:ok, %Deck{} = deck} <- Decks.create_deck(conn.assigns.user_id, deck_params) do
+    deck_params_with_user_id = Map.put_new(deck_params, "user_id", conn.assigns.user_id)
+
+    with {:ok, %Deck{} = deck} <-
+           Decks.create_deck(deck_params_with_user_id) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", ~p"/decks/#{deck}")
@@ -21,36 +24,38 @@ defmodule SpacedRepWeb.DeckController do
   end
 
   def show(conn, %{"id" => id}) do
-    with %Deck{} = deck <- Decks.get_deck(id) do
+    with %Deck{} = deck <- Decks.get_deck(%{"id" => id, "user_id" => conn.assigns.user_id}) do
       render(conn, :show, deck: deck)
     end
   end
 
   def update(conn, %{"id" => id} = deck_params) do
-    with %Deck{} = deck <- Decks.get_deck(id),
-         {:ok, %Deck{} = deck} <-
-           Decks.update_deck(deck, deck_params) do
+    with {:ok, %Deck{} = deck} <-
+           Decks.update_deck(id, Map.put_new(deck_params, "user_id", conn.assigns.user_id)) do
       render(conn, :show, deck: deck)
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    with {:ok, %Deck{}} <- Decks.delete_deck(id) do
-      conn
-      |> resp(:no_content, "")
-      |> send_resp()
+    with {:ok, %Deck{}} <- Decks.delete_deck(%{"id" => id, "user_id" => conn.assigns.user_id}) do
+      send_resp(conn, :no_content, "")
     end
   end
 
   def upload(conn, _opts) do
-    case Decks.upload_decks(conn.assigns.data, conn.assigns.user_id) do
+    decks_with_user_id =
+      Enum.map(conn.assigns.data, fn deck ->
+        Map.put_new(deck, "user_id", conn.assigns.user_id)
+      end)
+
+    case Decks.upload_decks(decks_with_user_id) do
       {:ok, _} -> send_resp(conn, :created, "")
       {:error, _} -> send_resp(conn, :unprocessable_entity, "")
     end
   end
 
   def download(conn, _opts) do
-    with decks when is_list(decks) <- Decks.list_decks(),
+    with decks when is_list(decks) <- Decks.list_decks(conn.assigns.user_id),
          {:ok, content} <- Jason.encode(decks),
          {:ok, _} <- s3_put_object(conn, content),
          {:ok, url} <- s3_get_presigned_url(conn) do

--- a/lib/spaced_rep_web/endpoint.ex
+++ b/lib/spaced_rep_web/endpoint.ex
@@ -1,7 +1,8 @@
 defmodule SpacedRepWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :spaced_rep
 
-  plug SpacedRepWeb.Plug
+  plug SpacedRepWeb.Plugs.HealthCheck
+  plug SpacedRepWeb.Plugs.UserID
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.

--- a/lib/spaced_rep_web/plugs/health_check.ex
+++ b/lib/spaced_rep_web/plugs/health_check.ex
@@ -1,0 +1,14 @@
+# Reference: https://blog.jola.dev/health-checks-for-plug-and-phoenix
+defmodule SpacedRepWeb.Plugs.HealthCheck do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: "/health"} = conn, _opts) do
+    conn
+    |> send_resp(200, "healthy")
+    |> halt()
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/lib/spaced_rep_web/plugs/user_id.ex
+++ b/lib/spaced_rep_web/plugs/user_id.ex
@@ -1,0 +1,21 @@
+# Reference: https://blog.jola.dev/health-checks-for-plug-and-phoenix
+defmodule SpacedRepWeb.Plugs.UserID do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: "/health"} = conn, _opts) do
+    conn
+    |> send_resp(200, "healthy")
+    |> halt()
+  end
+
+  def call(conn, _opts) do
+    with [token] <- get_req_header(conn, "authorization"),
+         %JOSE.JWT{fields: %{"sub" => user_id}} <- JOSE.JWT.peek_payload(token) do
+      assign(conn, :user_id, user_id)
+    else
+      _ -> conn |> send_resp(404, "Nothing found") |> halt()
+    end
+  end
+end

--- a/lib/spaced_rep_web/plugs/user_id.ex
+++ b/lib/spaced_rep_web/plugs/user_id.ex
@@ -4,12 +4,6 @@ defmodule SpacedRepWeb.Plugs.UserID do
 
   def init(opts), do: opts
 
-  def call(%Plug.Conn{request_path: "/health"} = conn, _opts) do
-    conn
-    |> send_resp(200, "healthy")
-    |> halt()
-  end
-
   def call(conn, _opts) do
     with [token] <- get_req_header(conn, "authorization"),
          %JOSE.JWT{fields: %{"sub" => user_id}} <- JOSE.JWT.peek_payload(token) do

--- a/priv/repo/migrations/20240614160950_add_user_id_to_cards.exs
+++ b/priv/repo/migrations/20240614160950_add_user_id_to_cards.exs
@@ -1,0 +1,9 @@
+defmodule SpacedRep.Repo.Migrations.AddUserIdToCards do
+  use Ecto.Migration
+
+  def change do
+    alter table(:cards) do
+      add :user_id, :uuid, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20240614162325_add_user_id_to_answers.exs
+++ b/priv/repo/migrations/20240614162325_add_user_id_to_answers.exs
@@ -1,0 +1,9 @@
+defmodule SpacedRep.Repo.Migrations.AddUserIdToAnswers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:answers) do
+      add :user_id, :uuid, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20240617143447_add_deleted_at_to_answers.exs
+++ b/priv/repo/migrations/20240617143447_add_deleted_at_to_answers.exs
@@ -1,0 +1,9 @@
+defmodule SpacedRep.Repo.Migrations.AddDeletedAtToAnswers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:answers) do
+      add :deleted_at, :utc_datetime, null: true
+    end
+  end
+end

--- a/test/spaced_rep/answers_test.exs
+++ b/test/spaced_rep/answers_test.exs
@@ -11,7 +11,7 @@ defmodule SpacedRep.AnswersTest do
 
     loaded_answers = load_answers(answer.card_id)
 
-    assert loaded_answers = [answer]
+    assert loaded_answers == [answer]
   end
 
   test "get_answer/1" do
@@ -38,7 +38,7 @@ defmodule SpacedRep.AnswersTest do
       invalid_data = %{"content" => nil}
       created_answer = create_answer(card.id, invalid_data)
 
-      assert match?(created_answer, nil)
+      assert match?(^created_answer, nil)
     end
   end
 
@@ -86,7 +86,7 @@ defmodule SpacedRep.AnswersTest do
     Answers.get_answer(%{"id" => id, "user_id" => @user_id})
   end
 
-  defp create_answer(card_id, data \\ %{content: "some content"}) do
+  defp create_answer(card_id, data) do
     Answers.create_answer(%{"user_id" => @user_id, "card_id" => card_id}, data)
 
     case Answers.list_answers(%{"user_id" => @user_id, "card_id" => card_id}) do
@@ -96,7 +96,7 @@ defmodule SpacedRep.AnswersTest do
     end
   end
 
-  defp update_answer(id, data \\ %{}) do
+  defp update_answer(id, data) do
     Answers.update_answer(%{"id" => id, "user_id" => @user_id}, data)
     Answers.get_answer(%{"id" => id, "user_id" => @user_id})
   end

--- a/test/spaced_rep/answers_test.exs
+++ b/test/spaced_rep/answers_test.exs
@@ -1,57 +1,108 @@
 defmodule SpacedRep.AnswersTest do
   use SpacedRep.DataCase
 
-  alias SpacedRep.Answers
-  alias SpacedRep.Answers.Answer
   import SpacedRep.Factory
+  alias SpacedRep.Answers
 
-  describe "answers" do
-    @invalid_attrs %{content: nil}
+  @user_id Ecto.UUID.generate()
 
-    test "list_answers/1 returns all answers" do
-      answer = insert(:answer) |> reset_fields([:card])
-      assert Answers.list_answers(answer.card_id) == [answer]
+  test "list_answers/1" do
+    answer = setup_answer()
+
+    loaded_answers = load_answers(answer.card_id)
+
+    assert loaded_answers = [answer]
+  end
+
+  test "get_answer/1" do
+    answer = setup_answer()
+
+    loaded_answer = load_answer(answer.id)
+
+    assert loaded_answer == answer
+  end
+
+  describe "create_answer/1" do
+    test "when input data is valid" do
+      card = setup_card()
+
+      data = %{"content" => "How are you"}
+      created_answer = create_answer(card.id, data)
+
+      assert created_answer.content == data["content"]
     end
 
-    test "get_answer!/1 returns the answer with given id" do
-      answer = insert(:answer) |> reset_fields([:card])
-      assert Answers.get_answer!(answer.id) == answer
+    test "when input data is invalid" do
+      card = setup_card()
+
+      invalid_data = %{"content" => nil}
+      created_answer = create_answer(card.id, invalid_data)
+
+      assert match?(created_answer, nil)
+    end
+  end
+
+  describe "update_answer/2" do
+    test "when input data is valid" do
+      answer = setup_answer()
+
+      data = %{"content" => "some updated content"}
+      updated_answer = update_answer(answer.id, data)
+
+      assert updated_answer.content == data["content"]
     end
 
-    test "create_answer/1 with valid data creates a answer" do
-      valid_attrs = %{content: "some content"}
+    test "when input data is invalid" do
+      answer = setup_answer()
 
-      assert {:ok, %Answer{} = answer} = Answers.create_answer(valid_attrs)
-      assert answer.content == "some content"
+      invalid_data = %{"content" => nil}
+      updated_answer = update_answer(answer.id, invalid_data)
+
+      assert updated_answer.content
     end
+  end
 
-    test "create_answer/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Answers.create_answer(@invalid_attrs)
+  test "delete_answer/1" do
+    answer = setup_answer()
+
+    deleted_answer = delete_answer(answer.id)
+
+    assert deleted_answer.deleted_at
+  end
+
+  defp setup_answer do
+    insert(:answer, %{user_id: @user_id}) |> reset_fields([:card])
+  end
+
+  defp setup_card do
+    insert(:card, %{user_id: @user_id})
+  end
+
+  defp load_answers(card_id) do
+    Answers.list_answers(%{"user_id" => @user_id, "card_id" => card_id})
+  end
+
+  defp load_answer(id) do
+    Answers.get_answer(%{"id" => id, "user_id" => @user_id})
+  end
+
+  defp create_answer(card_id, data \\ %{content: "some content"}) do
+    Answers.create_answer(%{"user_id" => @user_id, "card_id" => card_id}, data)
+
+    case Answers.list_answers(%{"user_id" => @user_id, "card_id" => card_id}) do
+      [] -> nil
+      [created_answer] -> created_answer
+      [created_answer | _] -> created_answer
     end
+  end
 
-    test "update_answer/2 with valid data updates the answer" do
-      answer = insert(:answer) |> reset_fields([:card])
-      update_attrs = %{content: "some updated content"}
+  defp update_answer(id, data \\ %{}) do
+    Answers.update_answer(%{"id" => id, "user_id" => @user_id}, data)
+    Answers.get_answer(%{"id" => id, "user_id" => @user_id})
+  end
 
-      assert {:ok, %Answer{} = answer} = Answers.update_answer(answer, update_attrs)
-      assert answer.content == "some updated content"
-    end
-
-    test "update_answer/2 with invalid data returns error changeset" do
-      answer = insert(:answer) |> reset_fields([:card])
-      assert {:error, %Ecto.Changeset{}} = Answers.update_answer(answer, @invalid_attrs)
-      assert answer == Answers.get_answer!(answer.id)
-    end
-
-    test "delete_answer/1 deletes the answer" do
-      answer = insert(:answer)
-      assert {:ok, %Answer{}} = Answers.delete_answer(answer)
-      assert_raise Ecto.NoResultsError, fn -> Answers.get_answer!(answer.id) end
-    end
-
-    test "change_answer/1 returns a answer changeset" do
-      answer = insert(:answer) |> reset_fields([:card])
-      assert %Ecto.Changeset{} = Answers.change_answer(answer)
-    end
+  defp delete_answer(id) do
+    Answers.delete_answer(%{"id" => id, "user_id" => @user_id})
+    Answers.get_answer(%{"id" => id, "user_id" => @user_id})
   end
 end

--- a/test/spaced_rep/answers_test.exs
+++ b/test/spaced_rep/answers_test.exs
@@ -102,7 +102,7 @@ defmodule SpacedRep.AnswersTest do
   end
 
   defp delete_answer(id) do
-    Answers.delete_answer(%{"id" => id, "user_id" => @user_id})
-    Answers.get_answer(%{"id" => id, "user_id" => @user_id})
+    {:ok, answer} = Answers.delete_answer(%{"id" => id, "user_id" => @user_id})
+    answer
   end
 end

--- a/test/spaced_rep/cards_test.exs
+++ b/test/spaced_rep/cards_test.exs
@@ -190,7 +190,7 @@ defmodule SpacedRep.CardsTest do
   end
 
   defp delete_card(id) do
-    Cards.delete_card(%{"id" => id, "user_id" => @user_id})
-    Cards.get_card(%{"id" => id, "user_id" => @user_id})
+    {:ok, card} = Cards.delete_card(%{"id" => id, "user_id" => @user_id})
+    card
   end
 end

--- a/test/spaced_rep/cards_test.exs
+++ b/test/spaced_rep/cards_test.exs
@@ -2,162 +2,195 @@ defmodule SpacedRep.CardsTest do
   use SpacedRep.DataCase
 
   alias SpacedRep.Cards
-  alias SpacedRep.Cards.Card
 
   import SpacedRep.Factory
 
-  describe "cards" do
-    @invalid_attrs %{
+  @user_id Ecto.UUID.generate()
+
+  test "list_cards/1" do
+    card = setup_card()
+
+    loaded_cards = load_cards(card.deck_id)
+
+    assert loaded_cards == [card]
+  end
+
+  test "get_card/1" do
+    card = setup_card()
+
+    loaded_card = load_card(card.id)
+
+    assert loaded_card == card
+  end
+
+  describe "create_card/1" do
+    test "when input data is valid" do
+      deck = setup_deck()
+
+      data = %{
+        interval: 4,
+        quality: 1,
+        easiness: 1.3,
+        question: "some question",
+        deck_id: deck.id,
+        user_id: @user_id
+      }
+
+      created_card = create_card(deck.id, data)
+
+      assert created_card.interval == data.interval
+      assert created_card.quality == data.quality
+      assert created_card.easiness == data.easiness
+      assert created_card.question == data.question
+    end
+
+    test "when input data is invalid" do
+      deck = setup_deck()
+
+      invalid_data = %{"question" => nil}
+      created_card = create_card(deck.id, invalid_data)
+
+      assert match?(^created_card, nil)
+    end
+  end
+
+  describe "update_card/2 when new quality is more than 3" do
+    test "repetitions is 0" do
+      card = setup_card(%{repetitions: 0})
+
+      data = %{
+        "quality" => 4
+      }
+
+      updated_card = update_card(card.id, data)
+
+      assert updated_card.quality == data["quality"]
+      assert updated_card.repetitions == 1
+      assert updated_card.interval == 1
+    end
+
+    test "repetitions is 1" do
+      card = setup_card(%{repetitions: 1})
+
+      data = %{
+        "quality" => 4
+      }
+
+      updated_card = update_card(card.id, data)
+
+      assert updated_card.quality == data["quality"]
+      assert updated_card.repetitions == 2
+      assert updated_card.interval == 6
+    end
+
+    test "repetitions is more than 1" do
+      card = setup_card(%{repetitions: 2, quality: 2, interval: 6, easiness: 4.1})
+
+      data = %{
+        "quality" => 4
+      }
+
+      updated_card = update_card(card.id, data)
+
+      assert updated_card.quality == data["quality"]
+      assert updated_card.easiness == 4.1
+      assert updated_card.repetitions == 3
+      # (easiness * interval) rounded
+      assert updated_card.interval == 24
+    end
+  end
+
+  # When quality is less than 3 the interval and repetitions are reset
+  # to 1 and 0 respectively. Since interval is what determines the next
+  # practice date, it is not necessary to update any of the other values
+  test "update_card/2 when new quality is less than 3" do
+    card = setup_card(%{interval: 6, quality: 4, repetitions: 5})
+
+    data = %{
+      "quality" => 2
+    }
+
+    updated_card = update_card(card.id, data)
+
+    assert updated_card.quality == data["quality"]
+    assert updated_card.repetitions == 0
+    assert updated_card.interval == 1
+  end
+
+  test "update_card/2 when new quality is same as incumbent quality" do
+    card = setup_card(%{quality: 1})
+
+    data = %{
+      "interval" => 4,
+      "quality" => 1,
+      "easiness" => 1.3,
+      "question" => "some updated question"
+    }
+
+    updated_card = update_card(card.id, data)
+
+    assert updated_card.interval == data["interval"]
+    assert updated_card.quality == data["quality"]
+    assert updated_card.easiness == data["easiness"]
+    assert updated_card.question == data["question"]
+  end
+
+  test "update_card/2 when input data is invalid" do
+    card = setup_card()
+
+    invalid_data = %{
       interval: nil,
       quality: nil,
       easiness: nil,
-      question: nil,
-      next_practice_date: nil
+      question: nil
     }
 
-    @tag :skip
-    test "list_cards/1 returns all cards" do
-      card = insert(:card) |> reset_fields([:deck])
-      assert Cards.list_cards(card.deck_id) == [card]
+    updated_card = update_card(card.id, invalid_data)
+
+    assert updated_card == card
+  end
+
+  test "delete_card/1" do
+    card = setup_card()
+
+    deleted_card = delete_card(card.id)
+
+    assert deleted_card.deleted_at
+  end
+
+  defp setup_card(data \\ %{}) do
+    insert(:card, Map.merge(%{user_id: @user_id}, data)) |> reset_fields([:deck])
+  end
+
+  defp setup_deck do
+    insert(:deck)
+  end
+
+  defp load_cards(deck_id) do
+    Cards.list_cards(%{"user_id" => @user_id, "deck_id" => deck_id})
+  end
+
+  defp load_card(id) do
+    Cards.get_card(%{"id" => id, "user_id" => @user_id})
+  end
+
+  defp create_card(deck_id, data) do
+    Cards.create_card(%{"user_id" => @user_id, "deck_id" => deck_id}, data)
+
+    case Cards.list_cards(%{"user_id" => @user_id, "deck_id" => deck_id}) do
+      [] -> nil
+      [created_card] -> created_card
+      [created_card | _] -> created_card
     end
+  end
 
-    @tag :skip
-    test "get_card/1 returns the card with given id" do
-      card = insert(:card) |> reset_fields([:deck])
-      assert Cards.get_card(card.id) == card
-    end
+  defp update_card(id, data) do
+    Cards.update_card(%{"id" => id, "user_id" => @user_id}, data)
+    Cards.get_card(%{"id" => id, "user_id" => @user_id})
+  end
 
-    @tag :skip
-    test "create_card/1 with minimal data" do
-      deck = insert(:deck)
-
-      valid_minimal_attrs = %{
-        question: "some minimal question",
-        deck_id: deck.id
-      }
-
-      assert {:ok, %Card{} = card} = Cards.create_card(valid_minimal_attrs)
-      assert card.interval == 1
-      assert card.quality == 3
-      assert card.easiness == 2.5
-      assert card.question == "some minimal question"
-      # TODO Add assertion for next_practice_date
-    end
-
-    @tag :skip
-    test "create_card/1 with valid data creates a card" do
-      deck = insert(:deck)
-
-      valid_attrs = %{
-        deck_id: deck.id,
-        interval: 4,
-        quality: 1,
-        easiness: 1.3,
-        question: "some question"
-      }
-
-      assert {:ok, %Card{} = card} = Cards.create_card(valid_attrs)
-      assert card.interval == 4
-      assert card.quality == 1
-      assert card.easiness == 1.3
-      assert card.question == "some question"
-    end
-
-    test "create_card/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Cards.create_card(@invalid_attrs)
-    end
-
-    test "update_card/2 when new quality is larger than 3 and repetitions is 0" do
-      card = insert(:card, %{repetitions: 0})
-
-      updated_attrs = %{
-        "quality" => 4
-      }
-
-      assert {:ok, %Card{} = card} = Cards.update_card(card, updated_attrs)
-      assert card.quality == 4
-      assert card.repetitions == 1
-      assert card.interval == 1
-    end
-
-    test "update_card/2 when new quality is larger than 3 and repetitions is 1" do
-      card = insert(:card, %{repetitions: 1})
-
-      updated_attrs = %{
-        "quality" => 4
-      }
-
-      assert {:ok, %Card{} = card} = Cards.update_card(card, updated_attrs)
-      assert card.quality == 4
-      assert card.repetitions == 2
-      assert card.interval == 6
-    end
-
-    test "update_card/2 when new quality is more than 3 and repetitions is more than 1" do
-      card = insert(:card, %{repetitions: 2, interval: 6, easiness: 4.1})
-
-      updated_attrs = %{
-        "quality" => 4
-      }
-
-      assert {:ok, %Card{} = card} = Cards.update_card(card, updated_attrs)
-
-      assert card.quality == 4
-      assert card.easiness == 4.1
-      assert card.repetitions == 3
-      # (easiness * interval) rounded
-      assert card.interval == 24
-    end
-
-    # When quality is less than 3 the interval and repetitions are reset
-    # to 1 and 0 respectively. Since interval is what determines the next
-    # practice date, it is not necessary to update any of the other values
-    test "update_card/2 when new quality is less than 3" do
-      card = insert(:card, %{interval: 6, repetitions: 5})
-
-      updated_attrs = %{
-        "quality" => 2
-      }
-
-      assert {:ok, %Card{} = card} = Cards.update_card(card, updated_attrs)
-      assert card.quality == 2
-      assert card.repetitions == 0
-      assert card.interval == 1
-    end
-
-    test "update_card/2 with valid data updates the card" do
-      card = insert(:card)
-
-      updated_attrs = %{
-        interval: 4,
-        quality: 1,
-        easiness: 1.3,
-        question: "some updated question"
-      }
-
-      assert {:ok, %Card{} = card} = Cards.update_card(card, updated_attrs)
-      assert card.interval == 4
-      assert card.quality == 1
-      assert card.easiness == 1.3
-      assert card.question == "some updated question"
-    end
-
-    @tag :skip
-    test "update_card/2 with invalid data returns error changeset" do
-      card = insert(:card) |> reset_fields([:deck])
-      assert {:error, %Ecto.Changeset{}} = Cards.update_card(card, @invalid_attrs)
-      assert card == Cards.get_card(card.id)
-    end
-
-    test "delete_card/1 deletes the card" do
-      card = insert(:card)
-      assert {:ok, %Card{}} = Cards.delete_card(card.id)
-      assert nil == Cards.get_card(card.id)
-    end
-
-    test "change_card/1 returns a card changeset" do
-      card = insert(:card)
-      assert %Ecto.Changeset{} = Cards.change_card(card)
-    end
+  defp delete_card(id) do
+    Cards.delete_card(%{"id" => id, "user_id" => @user_id})
+    Cards.get_card(%{"id" => id, "user_id" => @user_id})
   end
 end

--- a/test/spaced_rep/decks_test.exs
+++ b/test/spaced_rep/decks_test.exs
@@ -107,8 +107,8 @@ defmodule SpacedRep.DecksTest do
   end
 
   defp delete_deck(id) do
-    Decks.delete_deck(%{"id" => id, "user_id" => @user_id})
-    Decks.get_deck(%{"id" => id, "user_id" => @user_id})
+    {:ok, deck} = Decks.delete_deck(%{"id" => id, "user_id" => @user_id})
+    deck
   end
 
   defp reset_cards_field(deck) do

--- a/test/spaced_rep/decks_test.exs
+++ b/test/spaced_rep/decks_test.exs
@@ -2,7 +2,6 @@ defmodule SpacedRep.DecksTest do
   use SpacedRep.DataCase
 
   alias SpacedRep.Decks
-  alias SpacedRep.Decks.Deck
   import SpacedRep.Factory
 
   @user_id Ecto.UUID.generate()
@@ -29,7 +28,13 @@ defmodule SpacedRep.DecksTest do
     test "when input data is valid" do
       valid_data = %{
         "name" => "some name",
-        "description" => "some description"
+        "description" => "some description",
+        "cards" => [
+          %{
+            "question" => "Comment ça va?",
+            "answers" => [%{"content" => "How are you?"}, %{"content" => "How is it going?"}]
+          }
+        ]
       }
 
       created_deck = create_deck(valid_data)
@@ -43,7 +48,7 @@ defmodule SpacedRep.DecksTest do
 
       created_deck = create_deck(invalid_data)
 
-      assert match?(created_deck, nil)
+      assert match?(^created_deck, nil)
     end
   end
 
@@ -83,7 +88,7 @@ defmodule SpacedRep.DecksTest do
   end
 
   defp setup_deck() do
-    insert(:deck, %{user_id: @user_id})
+    insert(:deck, %{user_id: @user_id}) |> reset_fields([:cards])
   end
 
   defp create_deck(data) do

--- a/test/spaced_rep_web/controllers/answer_controller_test.exs
+++ b/test/spaced_rep_web/controllers/answer_controller_test.exs
@@ -2,7 +2,6 @@ defmodule SpacedRepWeb.AnswerControllerTest do
   use SpacedRepWeb.ConnCase
 
   import SpacedRep.Factory
-  alias SpacedRep.Answers.Answer
 
   alias SpacedRep.TestUtils, as: Utils
 
@@ -134,7 +133,7 @@ defmodule SpacedRepWeb.AnswerControllerTest do
     end
   end
 
-  defp setup_card(data \\ %{}) do
+  defp setup_card() do
     insert(:card, %{user_id: @user_id})
   end
 
@@ -160,10 +159,5 @@ defmodule SpacedRepWeb.AnswerControllerTest do
 
   defp delete_answer(conn, %{"deck_id" => deck_id, "card_id" => card_id, "id" => id}) do
     delete(conn, ~p"/decks/#{deck_id}/cards/#{card_id}/answers/#{id}")
-  end
-
-  defp create_answer(_) do
-    answer = insert(:answer, %{user_id: @user_id})
-    %{answer: answer}
   end
 end

--- a/test/spaced_rep_web/controllers/card_controller_test.exs
+++ b/test/spaced_rep_web/controllers/card_controller_test.exs
@@ -2,35 +2,12 @@ defmodule SpacedRepWeb.CardControllerTest do
   use SpacedRepWeb.ConnCase
 
   import SpacedRep.Factory
-  alias SpacedRep.Cards.Card
-  alias Ecto.UUID
   alias SpacedRep.TestUtils, as: Utils
 
-  @create_attrs %{
-    interval: 2,
-    quality: 1,
-    easiness: 1.3,
-    question: "some question",
-    answers: [%{content: "answer1"}],
-    next_practice_date: ~U[2023-06-16 21:19:00Z]
-  }
-  @update_attrs %{
-    interval: 2,
-    quality: 1,
-    easiness: 1.3,
-    question: "some updated question",
-    next_practice_date: ~U[2023-06-17 21:19:00Z]
-  }
-  @invalid_attrs %{
-    interval: nil,
-    quality: nil,
-    easiness: 1,
-    question: nil,
-    next_practice_date: nil
-  }
+  @user_id Ecto.UUID.generate()
 
   setup %{conn: conn} do
-    token = Utils.get_token(%{"sub" => UUID.autogenerate()})
+    token = Utils.get_token(%{"sub" => @user_id})
 
     conn =
       conn
@@ -41,10 +18,9 @@ defmodule SpacedRepWeb.CardControllerTest do
   end
 
   describe "index" do
-    setup [:create_card]
-
-    test "lists all cards", %{conn: conn, card: %Card{deck_id: deck_id} = card} do
-      conn = get(conn, ~p"/decks/#{deck_id}/cards")
+    test "lists all cards", %{conn: conn} do
+      card = insert(:card, %{user_id: @user_id})
+      conn = get(conn, ~p"/decks/#{card.deck_id}/cards")
 
       assert json_response(conn, 200) == [
                %{
@@ -62,86 +38,114 @@ defmodule SpacedRepWeb.CardControllerTest do
     end
   end
 
-  describe "create card" do
-    setup [:create_card]
-
-    test "renders card when data is valid", %{
-      conn: conn,
-      card: %Card{deck_id: deck_id}
+  describe "POST /cards" do
+    test "when input data is valid", %{
+      conn: conn
     } do
-      conn = post(conn, ~p"/decks/#{deck_id}/cards", @create_attrs)
+      deck = setup_deck()
 
-      assert(%{"id" => id} = json_response(conn, 201))
+      valid_data = %{
+        "interval" => 2,
+        "quality" => 1,
+        "easiness" => 1.3,
+        "question" => "some question",
+        # TODO re-introduce after custom body parser is written
+        # "answers" => [%{"content" => "answer1"}]
+        "answers" => []
+      }
 
-      conn = get(conn, ~p"/decks/#{deck_id}/cards/#{id}")
+      conn = post_card(conn, deck.id, valid_data)
 
-      %{easiness: easiness, interval: interval, question: question, quality: quality} =
-        @create_attrs
-
-      assert %{
-               "id" => ^id,
-               "easiness" => ^easiness,
-               "interval" => ^interval,
-               "next_practice_date" => "2023-06-16T21:19:00Z",
-               "quality" => ^quality,
-               "question" => ^question
-               #  TODO add answers to assertion
-             } = json_response(conn, 200)
+      resp = json_response(conn, 201)
+      assert resp["easiness"] == valid_data["easiness"]
+      assert resp["interval"] == valid_data["interval"]
+      assert resp["quality"] == valid_data["quality"]
+      assert resp["question"] == valid_data["question"]
     end
 
-    test "renders errors when data is invalid", %{conn: conn, card: %Card{deck_id: deck_id}} do
-      conn = post(conn, ~p"/decks/#{deck_id}/cards", @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
+    test "when input data is invalid", %{conn: conn} do
+      deck = setup_deck()
+
+      invalid_data = %{
+        question: nil
+      }
+
+      conn =
+        post_card(
+          conn,
+          deck.id,
+          invalid_data
+        )
+
+      resp = json_response(conn, 422)
+      assert resp["errors"]
     end
   end
 
-  describe "update card" do
-    setup [:create_card]
-
-    test "renders card when data is valid", %{
-      conn: conn,
-      card: %Card{id: id, deck_id: deck_id} = card
+  describe "PUT /cards/:id" do
+    test "when input data is valid", %{
+      conn: conn
     } do
-      conn = put(conn, ~p"/decks/#{deck_id}/cards/#{id}", @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)
+      card = setup_card()
 
-      conn = get(conn, ~p"/decks/#{deck_id}/cards/#{card.id}")
+      valid_data = %{
+        "interval" => 2,
+        "quality" => 1,
+        "easiness" => 1.3,
+        "question" => "some updated question"
+      }
 
-      assert %{
-               "id" => ^id,
-               "easiness" => 1.3,
-               "interval" => 2,
-               "next_practice_date" => "2023-06-17T21:19:00Z",
-               "quality" => 1,
-               "question" => "some updated question"
-             } = json_response(conn, 200)
+      conn = put_card(conn, %{"id" => card.id, "deck_id" => card.deck_id}, valid_data)
+
+      resp = json_response(conn, 200)
+
+      assert resp["easiness"] == valid_data["easiness"]
+      assert resp["interval"] == valid_data["interval"]
+      assert resp["quality"] == valid_data["quality"]
+      assert resp["question"] == valid_data["question"]
     end
 
     # TODO Fix this test
-    @tag :skip
-    test "renders errors when data is invalid", %{
-      conn: conn,
-      card: %Card{id: id, deck_id: deck_id}
+
+    test "when input data is invalid", %{
+      conn: conn
     } do
-      conn = put(conn, ~p"/decks/#{deck_id}/cards/#{id}", @invalid_attrs)
-      assert json_response(conn, 422)["errors"] != %{}
+      card = setup_card()
+
+      invalid_data = %{question: nil}
+
+      conn = put_card(conn, %{"id" => card.id, "deck_id" => card.deck_id}, invalid_data)
+
+      resp = json_response(conn, 422)
+      assert resp["errors"]
     end
   end
 
-  describe "delete card" do
-    setup [:create_card]
+  test "DELETE /cards/:id", %{conn: conn} do
+    card = setup_card()
 
-    test "deletes chosen card", %{conn: conn, card: %Card{id: id, deck_id: deck_id}} do
-      conn = delete(conn, ~p"/decks/#{deck_id}/cards/#{id}")
-      assert response(conn, 204)
+    conn = delete_card(conn, %{"id" => card.id, "deck_id" => card.deck_id})
 
-      conn = get(conn, ~p"/decks/#{deck_id}/cards/#{id}")
-      assert response(conn, 404)
-    end
+    assert response(conn, 204)
   end
 
-  defp create_card(_) do
-    card = insert(:card)
-    %{card: card}
+  defp setup_deck() do
+    insert(:deck, %{user_id: @user_id})
+  end
+
+  defp setup_card() do
+    insert(:card, %{user_id: @user_id})
+  end
+
+  defp post_card(conn, deck_id, data) do
+    post(conn, ~p"/decks/#{deck_id}/cards", data)
+  end
+
+  defp put_card(conn, %{"id" => id, "deck_id" => deck_id}, data) do
+    put(conn, ~p"/decks/#{deck_id}/cards/#{id}", data)
+  end
+
+  defp delete_card(conn, %{"id" => id, "deck_id" => deck_id}) do
+    delete(conn, ~p"/decks/#{deck_id}/cards/#{id}")
   end
 end

--- a/test/spaced_rep_web/controllers/deck_controller_test.exs
+++ b/test/spaced_rep_web/controllers/deck_controller_test.exs
@@ -28,16 +28,24 @@ defmodule SpacedRepWeb.DeckControllerTest do
   end
 
   describe "POST /decks" do
+    @tag :wip
     test "when input data is valid", %{conn: conn} do
       valid_data = %{
-        "name" => "some name",
-        "description" => "some description"
+        "name" => "Français",
+        "description" => "French terms",
+        "cards" => [
+          %{
+            "question" => "Comment ça va?",
+            "answers" => [%{"content" => "How are you?"}, %{"content" => "How is it going?"}]
+          }
+        ]
       }
 
       conn = post_deck(conn, valid_data)
 
       resp = json_response(conn, 201)
       assert resp["description"] == valid_data["description"]
+      assert Enum.count(resp["cards"]) == Enum.count(valid_data["cards"])
     end
 
     test "when input data is invalid", %{conn: conn} do

--- a/test/spaced_rep_web/controllers/plug_test.exs
+++ b/test/spaced_rep_web/controllers/plug_test.exs
@@ -1,15 +1,11 @@
-defmodule SpacedRepWeb.HealthCheckControllerTest do
+defmodule SpacedRepWeb.UserIDTest do
   use SpacedRepWeb.ConnCase
 
   alias SpacedRep.TestUtils, as: Utils
 
+  @user_id Ecto.UUID.generate()
+
   describe "index" do
-    test "health", %{conn: conn} do
-      conn = get(conn, ~p"/health")
-
-      assert "healthy" = response(conn, 200)
-    end
-
     test "request without authorization token", %{conn: conn} do
       conn =
         conn
@@ -31,14 +27,14 @@ defmodule SpacedRepWeb.HealthCheckControllerTest do
     end
 
     test "request with valid token", %{conn: conn} do
-      token = Utils.get_token(%{"sub" => "dummy_user_id"})
+      token = Utils.get_token(%{"sub" => @user_id})
 
       conn =
         conn
         |> put_req_header("authorization", "bearer #{token}")
         |> get(~p"/decks")
 
-      assert conn.assigns.user_id == "dummy_user_id"
+      assert conn.assigns.user_id == @user_id
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,10 +5,19 @@ defmodule SpacedRep.Factory do
   alias SpacedRep.{Decks.Deck, Cards.Card, Answers.Answer}
 
   def deck_factory(attrs \\ %{}) do
+    user_id = UUID.autogenerate()
+
     deck_defaults = %{
-      user_id: UUID.autogenerate(),
+      user_id: user_id,
       name: "dummy deck",
-      description: "Dummy test deck"
+      description: "Dummy test deck",
+      cards: [
+        %{
+          question: "Dummy question",
+          answers: [%{content: "Dummy answers", user_id: user_id}],
+          user_id: user_id
+        }
+      ]
     }
 
     deck = Map.merge(deck_defaults, attrs)
@@ -16,14 +25,17 @@ defmodule SpacedRep.Factory do
   end
 
   def card_factory(attrs \\ %{}) do
+    user_id = UUID.generate()
+
     card_defaults = %{
       question: "dummy question",
-      answers: [],
+      answers: [%{content: "dummy answer", user_id: user_id}],
       easiness: 1.3,
       quality: 1,
       interval: 1,
       repetitions: 0,
       next_practice_date: DateTime.utc_now(),
+      user_id: user_id,
       deck: build(:deck)
     }
 
@@ -31,10 +43,11 @@ defmodule SpacedRep.Factory do
     struct(Card, card)
   end
 
-  def answer_factory(attrs \\ %{}) do
+  def answer_factory(%{user_id: user_id} = attrs) do
     answer_defaults = %{
       content: "some answer",
-      card: insert(:card)
+      user_id: user_id,
+      card: insert(:card, %{user_id: user_id})
     }
 
     answer = Map.merge(answer_defaults, attrs)


### PR DESCRIPTION
This MR has changes so that user id field is added to all entities and access is restricted by user id in queries. 

Most of the changes however are not related to that, they are refactoring and clean up.This is far from ideal but this is the first project in phoenix and ecto so the initial code was inevitably lacking.

Closes #49 